### PR TITLE
Fixes a warning appears when creating new content

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -83,8 +83,8 @@ class Extension extends BaseExtension
         $parentValues = $context['content']->values;
         $values = array();
         if (array_key_exists($key, $parentValues)) {
-            $values = json_decode($parentValues[$key], true);
-            $values = array_values($values);
+            $json = json_decode($parentValues[$key], true);
+            $values = ($json) ? array_values($json) : array();
         }
 
         foreach ($values as $num => $vFields) {


### PR DESCRIPTION
Bolt 2.2.13.
While creating new content according to dump function $parentValues contain an empty string as current value. So it couldn't be decoded and appears some warnings.

Warning: array_values() expects parameter 1 to be array, null given in extensions/vendor/ws/array-field-type-extension/src/Extension.php on line 87
Warning: Invalid argument supplied for foreach() in extensions/vendor/ws/array-field-type-extension/src/Extension.php on line 90
