### PR TITLE
Make field nullable instead of set default value

### DIFF
--- a/src/ArrayField.php
+++ b/src/ArrayField.php
@@ -37,7 +37,7 @@ class ArrayField implements FieldInterface
     {
         return array(
             'children' => array(),
-            'default' => ''
+            'nullable' => true,
         );
     }
 }


### PR DESCRIPTION
Make field nullable instead of setting default value for prevent bolt integrity checker fail 
See #1 #2 
