### PR TITLE
Prevent error when no value has been set

### DIFF
--- a/src/StorageListener.php
+++ b/src/StorageListener.php
@@ -40,7 +40,7 @@ class StorageListener implements EventSubscriberInterface
         $content = $event->getContent();
 
         foreach ($content->contenttype['fields'] as $key => $options) {
-            if ($options['type'] == 'array') {
+            if ($options['type'] == 'array' && is_array($content->values[$key]) === true) {
                 $content->values[$key] = json_encode(array_values($content->values[$key]));
             }
         }


### PR DESCRIPTION
When creating a new page with the field not required the StorageListener throws an error because array_values is receiving a string instead of an array.

If we check if received value is an actual array the error is averted. 

Edit: Just realised that there was a closed PR for a similar issue: https://github.com/WedgeSama/array-field-type-extension/pull/3
